### PR TITLE
Reduce number of allocations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
+sudo: false
 language: go
 
 go:
-  - 1.2
-  - 1.3
-  - 1.4
-  - 1.5
+  - 1.6
+  - 1.7
+  - tip
+
+matrix:
+  allow_failures:
+    - go: tip
 
 install:
   - mkdir -p $HOME/gopath/src/gopkg.in

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 all:
-	go test ./... -test.v -test.cpu=1,2,4
-	go test ./... -test.v -test.short -test.race
+	go test ./...
+	go test ./... -short -race
+	go vet

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,30 @@
+package sourcemap_test
+
+import (
+	"testing"
+
+	"gopkg.in/sourcemap.v1"
+)
+
+func BenchmarkParse(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := sourcemap.Parse(jqSourceMapURL, jqSourceMapBytes)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSource(b *testing.B) {
+	smap, err := sourcemap.Parse(jqSourceMapURL, jqSourceMapBytes)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 10; j++ {
+			smap.Source(j, 100*j)
+		}
+	}
+}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -92,7 +92,7 @@ func TestSourceMap(t *testing.T) {
 
 	_, _, _, _, ok := smap.Source(3, 0)
 	if ok {
-		t.Fatal()
+		t.Fatal("source must not exist")
 	}
 }
 

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -175,29 +175,6 @@ func TestJQuerySourceMap(t *testing.T) {
 	}
 }
 
-func BenchmarkParse(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_, err := sourcemap.Parse(jqSourceMapURL, jqSourceMapBytes)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkSource(b *testing.B) {
-	smap, err := sourcemap.Parse(jqSourceMapURL, jqSourceMapBytes)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10; j++ {
-			smap.Source(j, 100*j)
-		}
-	}
-}
-
 // This is a test mapping which maps functions from two different files
 // (one.js and two.js) to a minified generated source.
 //


### PR DESCRIPTION
```
benchmark            old ns/op     new ns/op     delta
BenchmarkParse-4     10292833      5035375       -51.08%

benchmark            old allocs     new allocs     delta
BenchmarkParse-4     99529          2312           -97.68%

benchmark            old bytes     new bytes     delta
BenchmarkParse-4     5953245       4397716       -26.13%
```