### PR TITLE
Better detection that a value should be pushed

### DIFF
--- a/mappings.go
+++ b/mappings.go
@@ -23,8 +23,9 @@ type mappings struct {
 	rd  *strings.Reader
 	dec base64vlq.Decoder
 
-	hasName bool
-	value   mapping
+	hasValue bool
+	hasName  bool
+	value    mapping
 
 	values []mapping
 }
@@ -91,6 +92,7 @@ func (m *mappings) parse() error {
 			if err != nil {
 				return err
 			}
+			m.hasValue = true
 		}
 	}
 }
@@ -142,10 +144,10 @@ func parseNamesInd(m *mappings) (fn, error) {
 }
 
 func (m *mappings) pushValue() {
-	if m.value.sourceLine == 1 && m.value.sourceColumn == 0 {
+	if !m.hasValue {
 		return
 	}
-
+	m.hasValue = false
 	if m.hasName {
 		m.values = append(m.values, m.value)
 		m.hasName = false

--- a/mappings_test.go
+++ b/mappings_test.go
@@ -1,0 +1,32 @@
+package sourcemap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseMappings(t *testing.T) {
+	t.Parallel()
+	cases := map[string][]mapping{
+		";;;;;;kBAEe,YAAY,CAC1B,C;;AAHD": {
+			{genLine: 7, genColumn: 18, sourceLine: 3, sourceColumn: 15, namesInd: -1},
+			{genLine: 7, genColumn: 30, sourceLine: 3, sourceColumn: 27, namesInd: -1},
+			{genLine: 7, genColumn: 31, sourceLine: 4, sourceColumn: 1, namesInd: -1},
+			{genLine: 7, genColumn: 32, sourceLine: 4, sourceColumn: 1, namesInd: -1},
+			{genLine: 9, genColumn: 0, sourceLine: 1, sourceColumn: 0, namesInd: -1},
+		},
+	}
+	for k, c := range cases {
+		k, c := k, c
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+			v, err := parseMappings(k)
+			if err != nil {
+				t.Fatalf("got error %s", err)
+			}
+			if !reflect.DeepEqual(v, c) {
+				t.Fatalf("expected %v got %v", c, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This probably should get more tests, but I got this particular mapping while trying some things around https://github.com/grafana/k6/pull/2082 and it turned out to totally not work because it was pointing to 1:0 in the original file.

The source map is generated from (a very old version of) babel so I think it's possible for something else to generate a similar source map and for it to not be parsed correctly.