### PR TITLE
Exclude empty mappings

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -195,6 +195,10 @@ func (c *Consumer) source(
 	var match *mapping
 	// Mapping not found
 	if i == len(m.mappings) {
+		// Empty mappings
+		if len(m.mappings) == 0 {
+			return
+		}
 		// lets see if the line is correct but the column is bigger
 		match = &m.mappings[i-1]
 		if int(match.genLine) != genLine {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -66,6 +66,23 @@ func (test *sourceMapTest) assert(t *testing.T, smap *sourcemap.Consumer) {
 	}
 }
 
+func TestSourceWithEmptySourceMap(t *testing.T) {
+	var jsmap = `{
+  "version": 3,
+  "mappings": ";;"
+}`
+
+	smap, err := sourcemap.Parse("noname", []byte(jsmap))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, _, _, matched := smap.Source(1, 1)
+	if matched {
+		t.Error("it is unexpected to match an empty SourceMap")
+	}
+}
+
 func TestSourceMap(t *testing.T) {
 	testSourceMap(t, sourceMapJSON)
 }


### PR DESCRIPTION
In case `m.mappings` is empty then the current flow panics because it tries to access a previous (but non-existent) item. The patch simply restored the removed check from https://github.com/go-sourcemap/sourcemap/commit/73a0ee2ad6086891e4fcf116763e2a239693cfea.

Related to https://github.com/grafana/k6/issues/3556