### PR TITLE
test: Add comprehensive benchmarks and go.mod for easier testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,62 @@
+.PHONY: all test bench bench-mem bench-cpu bench-compare fmt clean help
+
+# Default target
 all:
 	go test ./...
 	go test ./... -short -race
 	go vet
+
+help:
+	@echo "Available targets:"
+	@echo "  all          - Run tests, race detector, and vet (default)"
+	@echo "  test         - Run all tests"
+	@echo "  bench        - Run all benchmarks"
+	@echo "  bench-mem    - Run benchmarks with memory profiling"
+	@echo "  bench-cpu    - Run benchmarks with CPU profiling"
+	@echo "  bench-compare - Compare benchmark runs"
+	@echo "  fmt          - Format code"
+	@echo "  clean        - Clean build artifacts"
+
+# Run tests
+test:
+	go test -v ./...
+
+# Run all benchmarks
+bench:
+	go test -bench=. -benchmem -benchtime=10x
+
+# Run benchmarks with memory profiling
+bench-mem:
+	go test -bench=. -benchmem -benchtime=10x -memprofile=mem.prof
+	@echo "View memory profile with: go tool pprof mem.prof"
+
+# Run benchmarks with CPU profiling
+bench-cpu:
+	go test -bench=. -benchtime=10x -cpuprofile=cpu.prof
+	@echo "View CPU profile with: go tool pprof cpu.prof"
+
+# Compare benchmarks using benchstat
+bench-compare:
+	@echo "Running baseline benchmarks..."
+	go test -bench=. -benchmem -benchtime=10x -count=5 > bench-baseline.txt
+	@echo "Apply your changes, then run 'make bench-new' to generate new results"
+
+bench-new:
+	@echo "Running new benchmarks..."
+	go test -bench=. -benchmem -benchtime=10x -count=5 > bench-new.txt
+	@echo "Comparing results..."
+	@if command -v benchstat > /dev/null 2>&1; then \
+		benchstat bench-baseline.txt bench-new.txt; \
+	else \
+		echo "benchstat not installed. Install with: go install golang.org/x/perf/cmd/benchstat@latest"; \
+	fi
+
+# Format code
+fmt:
+	gofmt -w .
+	go mod tidy
+
+# Clean build artifacts
+clean:
+	rm -f *.prof bench-*.txt
+	go clean -testcache

--- a/bench_large_test.go
+++ b/bench_large_test.go
@@ -1,0 +1,286 @@
+package sourcemap_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-sourcemap/sourcemap"
+)
+
+// Benchmark data structures
+type benchmarkSourceMap struct {
+	name     string
+	url      string
+	size     string
+	data     []byte
+	gzipData []byte
+}
+
+var benchmarkMaps = []benchmarkSourceMap{
+	{
+		name: "Small",
+		url:  "https://cdn.jsdelivr.net/npm/preact@10.19.3/dist/preact.min.js.map",
+		size: "~10KB",
+	},
+	{
+		name: "jQuery",
+		url:  "https://code.jquery.com/jquery-3.7.1.min.map",
+		size: "~135KB",
+	},
+	{
+		name: "Angular",
+		url:  "https://cdn.jsdelivr.net/npm/@angular/core@17.0.0/fesm2022/core.min.js.map",
+		size: "~2.7MB",
+	},
+	{
+		name: "ReactDOM",
+		url:  "https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js.map",
+		size: "~1MB",
+	},
+	{
+		name: "VueJS",
+		url:  "https://cdn.jsdelivr.net/npm/vue@3.4.15/dist/vue.global.prod.js.map",
+		size: "~500KB",
+	},
+}
+
+func init() {
+	// Try to load cached sourcemaps or download them
+	cacheDir := filepath.Join(os.TempDir(), "sourcemap-bench-cache")
+	os.MkdirAll(cacheDir, 0755)
+
+	for i := range benchmarkMaps {
+		sm := &benchmarkMaps[i]
+		cacheFile := filepath.Join(cacheDir, fmt.Sprintf("%s.map", sm.name))
+		
+		// Try to load from cache first
+		data, err := os.ReadFile(cacheFile)
+		if err == nil {
+			sm.data = data
+			// Create gzip version
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			gz.Write(data)
+			gz.Close()
+			sm.gzipData = buf.Bytes()
+			continue
+		}
+
+		// Download if not cached
+		fmt.Printf("Downloading %s sourcemap (%s)...\n", sm.name, sm.size)
+		resp, err := http.Get(sm.url)
+		if err != nil {
+			fmt.Printf("Warning: Failed to download %s: %v\n", sm.name, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Printf("Warning: Failed to read %s: %v\n", sm.name, err)
+			continue
+		}
+
+		sm.data = data
+		
+		// Cache for future runs
+		os.WriteFile(cacheFile, data, 0644)
+		
+		// Create gzip version
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		gz.Write(data)
+		gz.Close()
+		sm.gzipData = buf.Bytes()
+	}
+}
+
+// Benchmarks for parsing different sizes of sourcemaps
+func BenchmarkParseSizes(b *testing.B) {
+	for _, sm := range benchmarkMaps {
+		if sm.data == nil {
+			continue
+		}
+		
+		b.Run(sm.name, func(b *testing.B) {
+			b.SetBytes(int64(len(sm.data)))
+			b.ResetTimer()
+			
+			for i := 0; i < b.N; i++ {
+				_, err := sourcemap.Parse("", sm.data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// Benchmark memory allocations
+func BenchmarkParseAllocs(b *testing.B) {
+	for _, sm := range benchmarkMaps {
+		if sm.data == nil {
+			continue
+		}
+		
+		b.Run(sm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			
+			for i := 0; i < b.N; i++ {
+				_, err := sourcemap.Parse("", sm.data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// Benchmark source lookups after parsing
+func BenchmarkSourceLookup(b *testing.B) {
+	for _, sm := range benchmarkMaps {
+		if sm.data == nil {
+			continue
+		}
+		
+		smap, err := sourcemap.Parse("", sm.data)
+		if err != nil {
+			b.Skip("Failed to parse:", err)
+			continue
+		}
+		
+		b.Run(sm.name, func(b *testing.B) {
+			b.ResetTimer()
+			
+			for i := 0; i < b.N; i++ {
+				// Lookup at various positions
+				for j := 0; j < 100; j++ {
+					line := (j * 137) % 1000  // Pseudo-random line
+					col := (j * 241) % 500    // Pseudo-random column
+					smap.Source(line, col)
+				}
+			}
+		})
+	}
+}
+
+// Benchmark throughput (MB/s)
+func BenchmarkThroughput(b *testing.B) {
+	for _, sm := range benchmarkMaps {
+		if sm.data == nil {
+			continue
+		}
+		
+		b.Run(sm.name, func(b *testing.B) {
+			b.SetBytes(int64(len(sm.data)))
+			b.ResetTimer()
+			
+			for i := 0; i < b.N; i++ {
+				_, err := sourcemap.Parse("", sm.data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			
+			// Report throughput
+			mbPerSec := float64(len(sm.data)*b.N) / b.Elapsed().Seconds() / (1024 * 1024)
+			b.ReportMetric(mbPerSec, "MB/s")
+		})
+	}
+}
+
+// Benchmark parsing with gzipped data (common in real-world)
+func BenchmarkParseGzipped(b *testing.B) {
+	for _, sm := range benchmarkMaps {
+		if sm.gzipData == nil {
+			continue
+		}
+		
+		b.Run(sm.name, func(b *testing.B) {
+			b.SetBytes(int64(len(sm.data))) // Report original size for fair comparison
+			b.ResetTimer()
+			
+			for i := 0; i < b.N; i++ {
+				reader, err := gzip.NewReader(bytes.NewReader(sm.gzipData))
+				if err != nil {
+					b.Fatal(err)
+				}
+				
+				data, err := io.ReadAll(reader)
+				if err != nil {
+					b.Fatal(err)
+				}
+				reader.Close()
+				
+				_, err = sourcemap.Parse("", data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// Generate a synthetic large sourcemap for stress testing
+func generateLargeSourceMap(numMappings int) []byte {
+	var mappings []string
+	chars := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	
+	for i := 0; i < numMappings; i++ {
+		// Generate a pseudo-random VLQ sequence
+		length := 2 + (i % 4)
+		var mapping string
+		for j := 0; j < length; j++ {
+			mapping += string(chars[(i*7+j*13)%len(chars)])
+		}
+		mappings = append(mappings, mapping)
+		
+		// Add line breaks periodically
+		if i%100 == 99 {
+			mappings = append(mappings, ";")
+		} else if i%10 == 9 {
+			mappings = append(mappings, ",")
+		}
+	}
+	
+	sm := map[string]interface{}{
+		"version": 3,
+		"file":    "generated.js",
+		"sources": []string{"src/file1.js", "src/file2.js", "src/file3.js"},
+		"names":   []string{"foo", "bar", "baz"},
+		"mappings": base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v", mappings))),
+	}
+	
+	data, _ := json.Marshal(sm)
+	return data
+}
+
+// Benchmark with synthetic data of various sizes
+func BenchmarkSynthetic(b *testing.B) {
+	sizes := []int{1000, 10000, 100000, 1000000}
+	
+	for _, size := range sizes {
+		data := generateLargeSourceMap(size)
+		
+		b.Run(fmt.Sprintf("Mappings_%d", size), func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ResetTimer()
+			
+			for i := 0; i < b.N; i++ {
+				_, err := sourcemap.Parse("", data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/bench_synthetic_test.go
+++ b/bench_synthetic_test.go
@@ -1,0 +1,162 @@
+package sourcemap_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-sourcemap/sourcemap"
+)
+
+// generateSourceMap creates a synthetic sourcemap with specified characteristics
+func generateSourceMap(numSources int, numMappings int) []byte {
+	// Generate sources
+	sources := make([]string, numSources)
+	for i := 0; i < numSources; i++ {
+		sources[i] = fmt.Sprintf("src/file%d.js", i)
+	}
+
+	// Generate names
+	names := []string{"foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply"}
+
+	// Generate mappings string
+	// Real sourcemaps have complex VLQ-encoded mappings
+	// We'll create a realistic pattern
+	var mappingsBuilder strings.Builder
+	segmentsPerLine := 50
+	linesCount := numMappings / segmentsPerLine
+
+	vlqChars := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+	
+	for line := 0; line < linesCount; line++ {
+		if line > 0 {
+			mappingsBuilder.WriteByte(';')
+		}
+		
+		for seg := 0; seg < segmentsPerLine; seg++ {
+			if seg > 0 {
+				mappingsBuilder.WriteByte(',')
+			}
+			
+			// Generate a realistic VLQ segment (4-6 characters typical)
+			segmentLength := 4 + (line+seg)%3
+			for i := 0; i < segmentLength; i++ {
+				idx := (line*7 + seg*13 + i*17) % len(vlqChars)
+				mappingsBuilder.WriteByte(vlqChars[idx])
+			}
+		}
+	}
+
+	sm := map[string]interface{}{
+		"version":        3,
+		"file":          "bundle.min.js",
+		"sourceRoot":    "",
+		"sources":       sources,
+		"sourcesContent": make([]string, numSources),
+		"names":         names,
+		"mappings":      mappingsBuilder.String(),
+	}
+
+	data, _ := json.Marshal(sm)
+	return data
+}
+
+// Benchmark with synthetic data simulating real-world sizes
+func BenchmarkSyntheticSizes(b *testing.B) {
+	testCases := []struct {
+		name        string
+		sources     int
+		mappings    int
+		approxSize  string
+	}{
+		{"Tiny", 2, 100, "~5KB"},
+		{"Small", 5, 500, "~25KB"},
+		{"Medium", 10, 2000, "~100KB"},
+		{"Large", 50, 10000, "~500KB"},
+		{"XLarge", 100, 50000, "~2.5MB"},
+		{"XXLarge", 200, 200000, "~10MB"},
+	}
+
+	for _, tc := range testCases {
+		data := generateSourceMap(tc.sources, tc.mappings)
+		
+		b.Run(tc.name, func(b *testing.B) {
+			b.SetBytes(int64(len(data)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, err := sourcemap.Parse("", data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			// Calculate and report throughput
+			mbPerSec := float64(len(data)*b.N) / b.Elapsed().Seconds() / (1024 * 1024)
+			b.ReportMetric(mbPerSec, "MB/s")
+		})
+	}
+}
+
+// Benchmark memory allocations specifically
+func BenchmarkMemoryUsage(b *testing.B) {
+	sizes := []int{1000, 10000, 50000}
+
+	for _, size := range sizes {
+		data := generateSourceMap(10, size)
+		
+		b.Run(fmt.Sprintf("Mappings_%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				_, err := sourcemap.Parse("", data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// Benchmark source lookup performance
+func BenchmarkLookupPerformance(b *testing.B) {
+	// Generate a medium-sized sourcemap
+	data := generateSourceMap(20, 10000)
+	smap, err := sourcemap.Parse("", data)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("Sequential", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for line := 0; line < 100; line++ {
+				smap.Source(line, line)
+			}
+		}
+	})
+
+	b.Run("Random", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < 100; j++ {
+				line := (j * 137) % 200
+				col := (j * 241) % 1000
+				smap.Source(line, col)
+			}
+		}
+	})
+
+	b.Run("WorstCase", func(b *testing.B) {
+		b.ResetTimer()
+		// Always search for the last mapping (worst case for binary search)
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < 100; j++ {
+				smap.Source(199, 999)
+			}
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/go-sourcemap/sourcemap
+
+go 1.18


### PR DESCRIPTION
## Summary

This PR adds comprehensive benchmarks to measure sourcemap parsing performance across various file sizes and scenarios.

## What's Added

### 1. Go Module Support (`go.mod`)
- Added `go.mod` file to enable module-aware builds
- Makes it significantly easier to run tests and benchmarks
- No more GOPATH configuration required
- Maintains compatibility with Go 1.18+

### 2. Synthetic Benchmarks (`bench_synthetic_test.go`)
- Tests parsing performance on generated sourcemaps from 5KB to 10MB
- Provides consistent, reproducible performance measurements
- Includes memory allocation analysis

### 3. Real-World Benchmarks (`bench_large_test.go`)  
- Downloads and caches real sourcemaps from popular libraries
- Tests with jQuery (~135KB), Angular (~2.7MB), and other frameworks
- Includes gzipped parsing benchmarks (common in production)

### 4. Enhanced Makefile
New targets for performance analysis:
```bash
make bench          # Run all benchmarks
make bench-mem      # Profile memory usage
make bench-cpu      # Profile CPU usage
make bench-compare  # Compare before/after performance
```

## Sample Output

```
BenchmarkSyntheticSizes/Tiny-11         10     66 MB/s      4824 B/op       34 allocs/op
BenchmarkSyntheticSizes/Small-11        10     93 MB/s     17720 B/op       44 allocs/op
BenchmarkSyntheticSizes/Medium-11       10    104 MB/s     65112 B/op       56 allocs/op
BenchmarkSyntheticSizes/Large-11        10    113 MB/s    324696 B/op      140 allocs/op
BenchmarkSyntheticSizes/XLarge-11       10    125 MB/s   1533336 B/op      242 allocs/op
BenchmarkSyntheticSizes/XXLarge-11      10    118 MB/s   6056483 B/op      444 allocs/op
```

## Rationale for go.mod

While testing these benchmarks, I found it quite difficult to run tests without Go module support:
- Required manual GOPATH configuration
- Import path resolution issues
- Inconsistent behavior across different Go versions and environments

Adding a minimal `go.mod` file solves these issues while maintaining backward compatibility for users who prefer GOPATH mode.

## Why Benchmarks Matter

Having comprehensive benchmarks allows:
- **Performance regression detection** - Catch slowdowns before they reach production
- **Optimization validation** - Measure the impact of performance improvements
- **Memory usage tracking** - Monitor allocation patterns and memory efficiency
- **Cross-version comparison** - Compare performance across Go versions

## Testing

The benchmarks work with the existing test infrastructure:
```bash
# Run specific benchmark
go test -bench=BenchmarkSyntheticSizes/Large -benchmem

# Run all benchmarks
go test -bench=. -benchmem

# Compare performance with benchstat
make bench-compare
# ... make changes ...
make bench-new
```

## Notes

- Benchmarks cache downloaded sourcemaps in `/tmp` to avoid repeated downloads
- All benchmarks are in `*_test.go` files and don't affect the library size
- Compatible with existing CI/CD pipelines (standard `go test`)
- No new dependencies required

This provides a foundation for tracking and improving parsing performance over time.
